### PR TITLE
Bugfix/Enhancement: Updated centering and align logic

### DIFF
--- a/src/plater/placer.rs
+++ b/src/plater/placer.rs
@@ -296,6 +296,9 @@ impl<'a> Placer<'a> {
 
         let res = Clone::clone(&self.smallest_observed_plate);
 
+        let bottom_left = (self.request.center_x - original_shape.width() / (2.0 * self.request.precision)
+                           , self.request.center_y - original_shape.height() / (2.0 * self.request.precision));
+
         let mut f = |i| {
             if let Some(x) = res {
                 if i >= x {
@@ -315,13 +318,19 @@ impl<'a> Placer<'a> {
                 original_shape.expand(original_shape.width() / self.request.precision)
             };
 
+            let center = if i <= n {
+                (self.request.center_x, self.request.center_y)
+            } else {
+                (bottom_left.0 + shape.width() / (2.0 * self.request.precision), bottom_left.1 + shape.height() / (2.0 * self.request.precision))
+            };
+
             let mut unlocked_parts = Vec::clone(&self.unlocked_parts);
             let mut plate = Plate::make_plate_with_placed_parts(
                 shape.as_ref(),
                 self.request.precision,
                 &mut Vec::clone(&self.locked_parts),
-                self.request.center_x,
-                self.request.center_y,
+                center.0,
+                center.1,
             )?;
 
 
@@ -349,7 +358,7 @@ impl<'a> Placer<'a> {
                         should_align_to_bed = true;
                         unlocked_parts.push(part);
                         shape = shape.expand(original_shape.width() / original_shape.resolution());
-                        plate = Plate::make_from_shape(&mut plate, shape.as_ref())
+                        plate = Plate::make_from_shape(&mut plate, shape.as_ref(), bottom_left)
                     }
                 }
             }

--- a/src/plater/plate.rs
+++ b/src/plater/plate.rs
@@ -25,15 +25,12 @@ pub struct Plate<'a> {
 
 impl<'a> Plate<'a> {
     pub(crate) fn align(&mut self, original_width: f64, original_height: f64) {
-        let (bottom_space, top_space, left_space, right_space) = self.bitmap.get_bound();
-        self.center();
-
-        let centered_width = self.width - left_space - right_space;
-        let tr_x = (original_width - centered_width) / 2.0;
+        let bound = self.bitmap.get_bound();
+        let (bottom_space, top_space, left_space, right_space) = bound;
 
         for part in &mut self.parts {
             let (x, y) = (part.get_x(), part.get_y());
-            part.set_offset(x - tr_x, y);
+            part.set_offset(x - left_space, y);
         }
     }
 
@@ -72,11 +69,14 @@ impl<'a> Plate<'a> {
         }
     }
 
-    pub(crate) fn make_from_shape(&mut self, shape: &dyn PlateShape) -> Self {
+    pub(crate) fn make_from_shape(&mut self, shape: &dyn PlateShape, bottom_left: (f64, f64)) -> Self {
+        let width = shape.width() / self.precision;
+        let height = shape.height() / self.precision;
+
         let mut next_plate = Plate::new(shape
                                         , self.precision
-                                        , self.center_x
-                                        , self.center_y);
+                                        , bottom_left.0 + width / 2.0
+                                        , bottom_left.1 + height / 2.0);
 
         let mut new_parts = Vec::with_capacity(self.parts.len());
         std::mem::swap(&mut new_parts, &mut self.parts);


### PR DESCRIPTION
When an oversized bed was chosen for placement previously, the origin of the bed in the placing algorithm was not set correctly.

For beds smaller than the actual bed, the center of the real bed and smaller beds coincide. (existing behavior)
For beds that are larger than the actual bed, the centers don't overlap.

This PR corrects this issue.

Additionally, the alignment logic has been updated to align the left side of oversized beds to the left side of the actual bed