### PR TITLE
Enhancement: Update field usage in code and bump version number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "pixelpack"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pixelpack"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/plater/part.rs
+++ b/src/plater/part.rs
@@ -8,8 +8,8 @@ pub struct Part {
     pub(crate) id: String,
     pub(crate) precision: f64,
     pub(crate) delta_r: f64,
-    _width: f64,
-    _height: f64,
+    pub(crate) width: f64,
+    pub(crate) height: f64,
     pub(crate) center_x: f64,
     pub(crate) center_y: f64,
     surface: f64,
@@ -61,8 +61,8 @@ impl Part {
             bitmaps,
             center_y,
             center_x,
-            _width: width as f64 + 2.0 * spacing,
-            _height: height as f64 + 2.0 * spacing,
+            width: width as f64 + 2.0 * spacing,
+            height: height as f64 + 2.0 * spacing,
             surface: 0.0,
         };
 

--- a/src/plater/placer.rs
+++ b/src/plater/placer.rs
@@ -141,11 +141,11 @@ impl<'a> Placer<'a> {
         };
 
         for part in request.parts.values() {
-            let (x, y) = (part.center_x, part.center_y);
+            let (off_x, off_y) = (part.center_x - part.width/2.0, part.center_y - part.height/2.0);
             let mut placed_part = PlacedPart::new_placed_part(part);
 
             if part.locked {
-                placed_part.set_offset(x, y);
+                placed_part.set_offset(off_x, off_y);
                 p.locked_parts.push(placed_part)
             } else {
                 p.unlocked_parts.push(placed_part);


### PR DESCRIPTION
### Issue Description:
In previous versions of the code, the fields `center_x` and `center_y` were being used as offsets instead of representing the actual center coordinates. While the code works, it is semantically incorrect.

### Changes

- To fix this issue, this pull request (PR) updates  the code to correctly compute the offsets using the center coordinates and the dimensions. This will ensure that the offsets are accurately calculated and the code functions as intended.

- Additionally, this PR includes a version bump to 0.4.0 to indicate that this change is a significant update to the code.

## Notes

Clients using this code will need to adjust values passed to this function
