### PR TITLE
Improved inter model spacing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "pixelpack"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pixelpack"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/plater/bitmap.rs
+++ b/src/plater/bitmap.rs
@@ -158,6 +158,30 @@ impl Bitmap {
         }
     }
 
+    pub fn top_left_dilate(&mut self, distance: i32) {
+        let width = self.width as usize;
+        let height = self.height as usize;
+
+        let mut old_version = Bitmap::clone(self);
+
+        for _ in 0..(distance as usize) {
+            // This is equivalent to cloning self, but reusing an allocation
+            old_version.initialize_data(self);
+            for y in 0..height {
+                for x in 0..width {
+                    if old_version.get_point(x as i32, y as i32) == 0 {
+                        if old_version.get_point(x as i32 + 1, y as i32) != 0
+                            || old_version.get_point(x as i32, y as i32 + 1) != 0
+                            || old_version.get_point(x as i32 + 1, y as i32 + 1) != 0
+                        {
+                            self.set_point(x as i32, y as i32, 1);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     pub fn dilate(&mut self, distance: i32) {
         let width = self.width as usize;
         let height = self.height as usize;
@@ -278,8 +302,8 @@ impl Bitmap {
 
         let old_center_x = self.center_x;
         let old_center_y = self.center_y;
-        let center_x = (width / 2) as f64;
-        let center_y = (height / 2) as f64;
+        let center_x = (width as f64 / 2.0);
+        let center_y = (height as f64 / 2.0);
 
         let mut rotated = Bitmap::new(width, height);
 
@@ -336,8 +360,8 @@ impl Bitmap {
             }
         }
 
-        let delta_x = max_x - min_x;
-        let delta_y = max_y - min_y;
+        let delta_x = max_x - min_x + 1;
+        let delta_y = max_y - min_y + 1;
         let mut trimmed = Bitmap::new(delta_x, delta_y);
         trimmed.center_x = self.center_x - min_x as f64;
         trimmed.center_y = self.center_y - min_y as f64;
@@ -352,7 +376,7 @@ impl Bitmap {
     }
 
     #[allow(dead_code)]
-    fn grow(&self, dx: i32, dy: i32) -> Self {
+    pub fn grow(&self, dx: i32, dy: i32) -> Self {
         let new_width = self.width + (2 * dx);
         let new_height = self.height + (2 * dy);
         let mut expanded = Bitmap::new(new_width, new_height);

--- a/src/plater/bitmap.rs
+++ b/src/plater/bitmap.rs
@@ -76,6 +76,11 @@ impl Bitmap {
         let center_y = self.center_x;
         let center_x = self.center_y;
 
+        let pixels = self.pixels;
+
+        let s_y = self.s_x;
+        let s_x = self.s_y;
+
         let mut data = Vec::with_capacity((width * height) as usize);
 
         for x in 0..self.width {
@@ -85,14 +90,13 @@ impl Bitmap {
         }
 
         Bitmap {
-            // TODO: consider populating empty values with actual values
             width,
             height,
             center_x,
             center_y,
-            s_x: 0,
-            s_y: 0,
-            pixels: 0,
+            s_x,
+            s_y,
+            pixels,
             data,
         }
     }

--- a/src/plater/bitmap.rs
+++ b/src/plater/bitmap.rs
@@ -15,6 +15,18 @@ const NEIGHBORS: [(i32, i32); 9] = [
     (1, 1),
 ];
 
+fn parse_int(input: f64) -> Option<i32> {
+    if (input - input.ceil()).abs() > 0.0001 {
+        return None;
+    }
+
+    if i32::MIN as f64 <= input && input <= i32::MAX as f64 {
+        return Some(input as i32);
+    }
+
+    return None;
+}
+
 pub struct Bitmap {
     // Image dimensions
     pub(crate) width: i32,
@@ -317,20 +329,33 @@ impl Bitmap {
     pub(crate) fn rotate(&self, mut r: f64) -> Self {
         r = -r;
 
-        let pi_factor = r / (PI / 2.0);
-        // ensure factor is an integer factor of pi/2
-        if f64::abs(pi_factor - pi_factor.ceil()) < 0.001 {
-            let n = f64::abs(pi_factor.ceil()) as i32 % 4;
-            if n == 0 {
+        // Apply special logic If the rotation angle is an integer multiple of pi/2 (90 degrees)
+        let pi_over_2_factor = r / (PI / 2.0);
+        match parse_int(pi_over_2_factor).map(|n| {
+            // normalize values to range of [0, 2*pi)
+            let value = n % 4;
+            if value < 0 {
+                4 + value
+            } else {
+                value
+            }
+        }) {
+            Some(0) => {
                 return self.clone();
             }
-
-            let mut bmp = self.clone();
-            for i in 0..n {
-                bmp = bmp.rotate_90_clockwise();
+            Some(1) => {
+                return self
+                    .rotate_90_clockwise()
+                    .rotate_90_clockwise()
+                    .rotate_90_clockwise();
             }
-
-            return bmp;
+            Some(2) => {
+                return self.rotate_90_clockwise().rotate_90_clockwise();
+            }
+            Some(3) => {
+                return self.rotate_90_clockwise();
+            }
+            _ => {}
         }
 
         let w = self.width as f64;

--- a/src/plater/bitmap.rs
+++ b/src/plater/bitmap.rs
@@ -1,4 +1,5 @@
 use std::cmp::{max, min};
+use std::f64::consts::PI;
 
 use crate::plater::util;
 
@@ -65,6 +66,34 @@ impl Bitmap {
             s_x: 0,
             s_y: 0,
             pixels: 0,
+        }
+    }
+
+    pub fn rotate_90_clockwise(&self) -> Self {
+        let width = self.height;
+        let height = self.width;
+
+        let center_y = self.center_x;
+        let center_x = self.center_y;
+
+        let mut data = Vec::with_capacity((width * height) as usize);
+
+        for x in 0..self.width {
+            for y in (0..self.height).rev() {
+                data.push(self.at(x, y));
+            }
+        }
+
+        Bitmap {
+            // TODO: consider populating empty values with actual values
+            width,
+            height,
+            center_x,
+            center_y,
+            s_x: 0,
+            s_y: 0,
+            pixels: 0,
+            data,
         }
     }
 
@@ -283,6 +312,22 @@ impl Bitmap {
 
     pub(crate) fn rotate(&self, mut r: f64) -> Self {
         r = -r;
+
+        let pi_factor = r / (PI / 2.0);
+        // ensure factor is an integer factor of pi/2
+        if f64::abs(pi_factor - pi_factor.ceil()) < 0.001 {
+            let n = f64::abs(pi_factor.ceil()) as i32 % 4;
+            if n == 0 {
+                return self.clone();
+            }
+
+            let mut bmp = self.clone();
+            for i in 0..n {
+                bmp = bmp.rotate_90_clockwise();
+            }
+
+            return bmp;
+        }
 
         let w = self.width as f64;
         let h = self.height as f64;

--- a/src/plater/bitmap.rs
+++ b/src/plater/bitmap.rs
@@ -449,7 +449,6 @@ impl Bitmap {
         trimmed
     }
 
-    #[allow(dead_code)]
     pub fn grow(&self, dx: i32, dy: i32) -> Self {
         let new_width = self.width + (2 * dx);
         let new_height = self.height + (2 * dy);

--- a/src/plater/part.rs
+++ b/src/plater/part.rs
@@ -32,8 +32,6 @@ impl Part {
         plate_width: f64,
         plate_height: f64,
         locked: bool,
-        dilation_spacing: i32,
-        top_left_spacing: i32,
     ) -> anyhow::Result<Self> {
         let trimmed_original = bitmap.trim();
         drop(bitmap);
@@ -62,25 +60,17 @@ impl Part {
                 .collect()
         };
 
-        let addition_spacing = dilation_spacing + top_left_spacing;
+        let rounded_spacing = spacing.ceil() as i32;
+        let dilation_spacing = rounded_spacing / 2;
+        let top_left_spacing = rounded_spacing % 2;
+
+        let spacing_growth = dilation_spacing + top_left_spacing;
 
         let bitmaps = undilated_bitmaps
             .into_iter()
-            .map(|x| {
-                // info!("Pre shrink");
-                // info!("{}", x.to_ppm());
-                x
-            })
             .map(|bmp| bmp.trim())
             .map(|bmp| {
-                // info!("Shrunk");
-                // info!("{}", bmp.to_ppm());
-                let mut bmp = bmp.grow(addition_spacing, addition_spacing);
-                //
-                // info!("Pre");
-                // info!("{}", bmp.to_ppm());
-
-                // TODO: ensure that the bmp has enough space present for the dilation to be applied. If the model goes to the ends of the bitmap, this entire exercise is futile. Add a buffer of dilation_spacign + top_left_spacign, idlate and then downsize
+                let mut bmp = bmp.grow(spacing_growth, spacing_growth);
                 if dilation_spacing > 0 {
                     bmp.dilate(dilation_spacing);
                 }
@@ -88,15 +78,7 @@ impl Part {
                 if top_left_spacing > 0 {
                     bmp.top_left_dilate(top_left_spacing);
                 }
-                //
-                // info!("Inter");
-                // info!("{}", bmp.to_ppm());
-
-                info!("Post");
-                let b = bmp.trim();
-                info!("{}", b.to_ppm());
-
-                b
+                bmp.trim()
             })
             .collect_vec();
 

--- a/src/plater/part.rs
+++ b/src/plater/part.rs
@@ -1,7 +1,6 @@
 use std::f64::consts::PI;
 
 use itertools::Itertools;
-use log::info;
 
 use crate::plater::bitmap::Bitmap;
 
@@ -47,9 +46,6 @@ impl Part {
 
         // if for every model there exists a rotation that is contained within,
         // we may attempt to place the model
-
-        info!("Original");
-        info!("{}", trimmed_original.to_ppm());
 
         let undilated_bitmaps = if locked {
             vec![trimmed_original]

--- a/src/plater/placer/helpers.rs
+++ b/src/plater/placer/helpers.rs
@@ -1,5 +1,5 @@
 use crate::plater::placed_part::PlacedPart;
-use crate::plater::placer::{N, Placer};
+use crate::plater::placer::{Placer, N};
 use crate::plater::plate::Plate;
 use crate::plater::plate_shape::PlateShape;
 use crate::plater::solution::Solution;

--- a/src/plater/placer/strategies.rs
+++ b/src/plater/placer/strategies.rs
@@ -3,13 +3,13 @@ use std::f64::consts::PI;
 
 use crate::plater::placed_part::PlacedPart;
 use crate::plater::placer::rect::Rect;
+use crate::plater::placer::score::Position::{Inside, Outside};
+use crate::plater::placer::score::Prefer;
+use crate::plater::placer::score::Preference::Second;
 use crate::plater::placer::score::{
     DefaultScoreWrapper, FloatWrapper, Score, ScoreWrapper, ScoreWrapperA, ScoreWrapperB,
     ScoreWrapperC, ScoreWrapperD,
 };
-use crate::plater::placer::score::Position::{Inside, Outside};
-use crate::plater::placer::score::Prefer;
-use crate::plater::placer::score::Preference::Second;
 use crate::plater::plate::Plate;
 use crate::plater::plate_shape::PlateShape;
 use crate::plater::request::Strategy;
@@ -49,18 +49,18 @@ impl<'a> Placer<'a> {
                     &mut plate.clone(),
                     &mut part,
                 )
-                    .or_else(|| {
-                        Placer::spiral_place::<ScoreWrapperA>(self, rs, &mut plate.clone(), &mut part)
-                    })
-                    .or_else(|| {
-                        Placer::spiral_place::<ScoreWrapperB>(self, rs, &mut plate.clone(), &mut part)
-                    })
-                    .or_else(|| {
-                        Placer::spiral_place::<ScoreWrapperC>(self, rs, &mut plate.clone(), &mut part)
-                    })
-                    .or_else(|| {
-                        Placer::spiral_place::<ScoreWrapperD>(self, rs, &mut plate.clone(), &mut part)
-                    }),
+                .or_else(|| {
+                    Placer::spiral_place::<ScoreWrapperA>(self, rs, &mut plate.clone(), &mut part)
+                })
+                .or_else(|| {
+                    Placer::spiral_place::<ScoreWrapperB>(self, rs, &mut plate.clone(), &mut part)
+                })
+                .or_else(|| {
+                    Placer::spiral_place::<ScoreWrapperC>(self, rs, &mut plate.clone(), &mut part)
+                })
+                .or_else(|| {
+                    Placer::spiral_place::<ScoreWrapperD>(self, rs, &mut plate.clone(), &mut part)
+                }),
             };
 
         if let Some((better_x, better_y, better_r)) = res {
@@ -185,12 +185,12 @@ impl<'a> Placer<'a> {
             self.request.plate_shape.width(),
             self.request.plate_shape.height(),
         )
-            .map(|(x, y)| {
-                (
-                    x + plate.center_x - plate.width / 2.0,
-                    y + plate.center_y - plate.height / 2.0,
-                )
-            });
+        .map(|(x, y)| {
+            (
+                x + plate.center_x - plate.width / 2.0,
+                y + plate.center_y - plate.height / 2.0,
+            )
+        });
 
         let cond = self.request.plate_shape.width() + (plate.center_x - plate.width / 2.0);
 

--- a/src/stl/part.rs
+++ b/src/stl/part.rs
@@ -42,9 +42,7 @@ pub(crate) fn load_model(
         spacing,
         plate_width,
         plate_height,
-        locked, // TODO
-        0,
-        0,
+        locked,
     )
     .ok()?;
 

--- a/src/stl/part.rs
+++ b/src/stl/part.rs
@@ -42,9 +42,11 @@ pub(crate) fn load_model(
         spacing,
         plate_width,
         plate_height,
-        locked,
+        locked, // TODO
+        0,
+        0,
     )
-        .ok()?;
+    .ok()?;
 
     Some((part, next_model))
 }


### PR DESCRIPTION
# Description

While testing, it was observed that inter-model during placements still had room for improvement.

# Changes

## Asymmetric padding when handling odd padding values

The current spacing logic only allows for even values to be handled correctly, as the logic uniformly adds pixels all around a given model. We now handle odd values of spacing, by adding another layer of spacing only to the top left of the model if required.

## Special handling of rotations of integer multiples of pi/2 (90 deg)

The current model rotation logic is the general solution to rotating bitmaps. It introduces a certain amount of error, which is unavoidable when it comes to handling arbitrary angles. It would however also introduce this error in the cases of 0, 90, 180, and 270 deg rotations which can be done perfectly. The PR adds code that implements this special rotation logic.

## Improvements to the trim behavior

The trim method for bitmaps contained an off-by-one error concerning the output dimensions. Changes were made in how float-integer casting is handled to reduce the error introduced.

## Applying spacing to models only post rotation

We now only add the spacing to models post-rotation. This change is required for Asymmetric padding but is also useful as it reduces the amount of aliasing that can occur.

# Note

Not all issues have been resolved, there is still a minor error of < 1 mm per model. This error occurs due to the resolution limits of the bitmap, and the fact that floating point coordinates can represent smaller distances than the bitmap. In practice, this does not appear to pose too much of an issue but should be investigated at a later date.