### PR TITLE
Reduce number of placers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pixelpack"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pixelpack"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/plater/request.rs
+++ b/src/plater/request.rs
@@ -188,15 +188,9 @@ impl Request {
         let sort_modes = Vec::clone(&self.sort_modes);
 
         for sort_mode in sort_modes {
-            for rotate_offset in 0..2 {
-                for rotate_direction in 0..2 {
-                    let mut placer = Placer::new(self);
-                    placer.sort_parts(sort_mode);
-                    placer.set_rotate_direction(rotate_direction);
-                    placer.set_rotate_offset(rotate_offset);
-                    placers.push(placer)
-                }
-            }
+            let mut placer = Placer::new(self);
+            placer.sort_parts(sort_mode);
+            placers.push(placer)
         }
 
         placers

--- a/src/plater/request.rs
+++ b/src/plater/request.rs
@@ -3,6 +3,7 @@ use std::f64::consts::PI;
 use std::time::Duration;
 
 use rand::prelude::SliceRandom;
+use rand::Rng;
 use thiserror::Error;
 
 use crate::plater::part::Part;
@@ -88,14 +89,8 @@ pub fn default_sort_modes() -> Vec<SortMode> {
     modes.push(SortMode::WidthDec);
     modes.push(SortMode::HeightDec);
 
-    for i in 0..21 {
-        modes.push(SortMode::Shuffle(i))
-    }
-
-    let shuffle_range: &mut [SortMode] = &mut (modes.as_mut_slice())[4..];
-
     let mut rng = rand::thread_rng();
-    shuffle_range.shuffle(&mut rng);
+    modes.push(SortMode::Shuffle(rng.gen()));
 
     modes
 }


### PR DESCRIPTION
### Issue

In practice, most arrange runs either need to only run a single placer or all of the placers to find a solution within a plate (if possible). A relatively small number of them use solutions that depend on the second and third placer. We can therefore reduce the number of simulations without too much of an impact.

### Changes

- Stop using the rotation offset and rotation_direction in `get_placers_for_spiral_place`
- Only include a single randomized sort mode in `default_sort_modes`
- Bump version number to `v0.7.1`