### PR TITLE
Bugfix/circle shape expansion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pixelpack"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pixelpack"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/plater/placer.rs
+++ b/src/plater/placer.rs
@@ -4,14 +4,14 @@ use std::fmt::Debug;
 use std::vec;
 
 use rand::rngs::StdRng;
-use rand::seq::SliceRandom;
 use rand::SeedableRng;
+use rand::seq::SliceRandom;
 
 use crate::plater::placed_part::PlacedPart;
+use crate::plater::placer::GravityMode::{GravityEQ, GravityXY, GravityYX};
 use crate::plater::placer::helpers::find_solution;
 use crate::plater::placer::rect::Rect;
-use crate::plater::placer::search::{binary_search, exponential_search_simple, Attempts};
-use crate::plater::placer::GravityMode::{GravityEQ, GravityXY, GravityYX};
+use crate::plater::placer::search::{Attempts, binary_search, exponential_search_simple};
 use crate::plater::plate::Plate;
 use crate::plater::plate_shape::PlateShape;
 use crate::plater::request::{BedExpansionMode, Request};
@@ -195,7 +195,7 @@ impl<'a> Placer<'a> {
         while !self.unlocked_parts.is_empty() {
             if expansion_needed {
                 // Expand and try again
-                shape = shape.expand(expand_mm);
+                shape = shape.extend_right(expand_mm);
                 plate = Plate::make_plate_with_placed_parts(
                     shape.as_ref(),
                     self.request.precision,
@@ -332,7 +332,7 @@ impl<'a> Placer<'a> {
                                 self.request.center_x,
                                 self.request.center_y,
                             )
-                            .unwrap();
+                                .unwrap();
                             solution.add_plate(next_plate);
                         }
                         current_part = part;

--- a/src/plater/placer/helpers.rs
+++ b/src/plater/placer/helpers.rs
@@ -1,5 +1,5 @@
 use crate::plater::placed_part::PlacedPart;
-use crate::plater::placer::{Placer, N};
+use crate::plater::placer::{N, Placer};
 use crate::plater::plate::Plate;
 use crate::plater::plate_shape::PlateShape;
 use crate::plater::solution::Solution;

--- a/src/plater/placer/helpers.rs
+++ b/src/plater/placer/helpers.rs
@@ -44,7 +44,7 @@ pub(crate) fn find_solution<'a, 'b>(
         original_shape.clone()
     } else {
         should_align_to_bed = true;
-        original_shape.expand(compute_scale_factor(search_index, N, K, 5.0))
+        original_shape.extend_right(compute_scale_factor(search_index, N, K, 5.0))
     };
 
     let center = if search_index <= N {

--- a/src/plater/plate.rs
+++ b/src/plater/plate.rs
@@ -64,9 +64,7 @@ impl<'a> Plate<'a> {
     ) -> Self {
         let width = shape.width();
         let height = shape.height();
-
-        let mut bitmap = Bitmap::new((width / precision) as i32, (height / precision) as i32);
-        shape.mask_bitmap(&mut bitmap, precision);
+        let bitmap = shape.make_masked_bitmap(precision);
 
         Plate {
             plate_id: generate_unique_plate_id(),

--- a/src/plater/plate_shape.rs
+++ b/src/plater/plate_shape.rs
@@ -7,7 +7,7 @@ pub trait PlateShape: Send + Sync {
     fn height(&self) -> f64;
     fn string(&self) -> String;
     fn make_masked_bitmap(&self, precision: f64) -> Bitmap;
-    fn expand(&self, size: f64) -> Box<dyn PlateShape>;
+    fn extend_right(&self, size: f64) -> Box<dyn PlateShape>;
     fn dyn_clone(&self) -> Box<dyn PlateShape>;
     fn contract(&self, size: f64) -> Option<Box<dyn PlateShape>>;
 }
@@ -89,7 +89,7 @@ impl PlateShape for PlateRectangle {
         Bitmap::new((width / precision) as i32, (height / precision) as i32)
     }
 
-    fn expand(&self, size: f64) -> Box<dyn PlateShape> {
+    fn extend_right(&self, size: f64) -> Box<dyn PlateShape> {
         Box::new(PlateRectangle {
             resolution: self.resolution,
             width: self.width * size,
@@ -206,11 +206,11 @@ impl PlateShape for PlateCircle {
     }
 
     // We return a rectangle when expanding a circle
-    fn expand(&self, size: f64) -> Box<dyn PlateShape> {
+    fn extend_right(&self, size: f64) -> Box<dyn PlateShape> {
         Box::new(PlateCircle {
             resolution: self.resolution,
             diameter: self.diameter,
-            plate_expansion_factor: size, // TODO: maybe this expansion should stack multiplicative
+            plate_expansion_factor: self.plate_expansion_factor * size,
         })
     }
 

--- a/src/plater/plate_shape.rs
+++ b/src/plater/plate_shape.rs
@@ -183,7 +183,7 @@ impl PlateShape for PlateCircle {
     }
 
     fn make_masked_bitmap(&self, precision: f64) -> Bitmap {
-        if self.plate_expansion_factor < 1.0 {
+        if self.plate_expansion_factor <= 1.0 {
             return make_standard_circle_bitmap(self, precision);
         }
 

--- a/src/plater/plate_shape.rs
+++ b/src/plater/plate_shape.rs
@@ -33,7 +33,7 @@ pub enum Shape {
 
 impl Shape {
     pub fn new_circle(diameter: f64, resolution: f64) -> Self {
-        Circle(PlateCircle::new(diameter, resolution))
+        Circle(PlateCircle::new(diameter, resolution, 1.0))
     }
 
     pub fn new_rectangle(width: f64, height: f64, resolution: f64) -> Self {
@@ -135,11 +135,11 @@ pub struct PlateCircle {
 }
 
 impl PlateCircle {
-    pub fn new(diameter: f64, resolution: f64) -> Self {
+    pub fn new(diameter: f64, resolution: f64, plate_expansion_factor: f64) -> Self {
         PlateCircle {
             resolution,
             diameter: diameter * resolution,
-            plate_expansion_factor: 1.0,
+            plate_expansion_factor,
         }
     }
 }
@@ -234,7 +234,7 @@ impl PlateShape for PlateCircle {
             return None;
         }
 
-        let circle = PlateCircle::new(width / self.resolution, self.resolution);
+        let circle = PlateCircle::new(width / self.resolution, self.resolution, self.plate_expansion_factor);
         Some(Box::new(circle))
     }
 }

--- a/src/plater/plate_shape.rs
+++ b/src/plater/plate_shape.rs
@@ -9,7 +9,6 @@ pub trait PlateShape: Send + Sync {
     fn make_masked_bitmap(&self, precision: f64) -> Bitmap;
     fn expand(&self, size: f64) -> Box<dyn PlateShape>;
     fn dyn_clone(&self) -> Box<dyn PlateShape>;
-    fn intersect_square(&self, size: f64) -> Option<Box<dyn PlateShape>>;
     fn contract(&self, size: f64) -> Option<Box<dyn PlateShape>>;
 }
 
@@ -104,21 +103,6 @@ impl PlateShape for PlateRectangle {
             width: self.width,
             height: self.height,
         })
-    }
-
-    fn intersect_square(&self, size: f64) -> Option<Box<dyn PlateShape>> {
-        if size <= 0.0 {
-            return None;
-        }
-
-        let width = self.width / self.resolution;
-        let height = self.height / self.resolution;
-
-        Some(Box::new(PlateRectangle::new(
-            f64::min(size, width),
-            f64::min(size, height),
-            self.resolution,
-        )))
     }
 
     fn contract(&self, size: f64) -> Option<Box<dyn PlateShape>> {
@@ -236,19 +220,6 @@ impl PlateShape for PlateCircle {
             diameter: self.diameter,
             plate_expansion_factor: self.plate_expansion_factor,
         })
-    }
-
-    fn intersect_square(&self, size: f64) -> Option<Box<dyn PlateShape>> {
-        if size <= 0.0 {
-            return None;
-        }
-
-        let diameter = self.diameter / self.resolution - size;
-        if diameter <= 0.0 {
-            None
-        } else {
-            Some(Box::new(PlateCircle::new(diameter, self.resolution)))
-        }
     }
 
     // Also mask bitmap


### PR DESCRIPTION
### Issue

The current bed expansion policy when attempting different plate sizes in the case of a rectangular bed is to extend the bed rightwards, with the bottom left of the bed fixed. So overflow parts would appear to the right of the printbed


The behaviour with circular beds was not the same, we would increase the diameter of the circle with the bottom left of the bed fixed.

The diagram below should explain the issue. It is worth noting that contracting the circle works as expected.

<img src="https://github.com/user-attachments/assets/cd4d7947-17b5-495e-821f-76d2602766eb4" width="400">


### Changes

- Make shapes fully in charge of generating masked bitmaps
- Rename `expand` to `extend_right` for clarity
- Remove unused function `intersect_square`
- Bump version to `0.9.0`